### PR TITLE
Fix small issues in ABC-SMC (#345)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ install:
   - pip install numpy
   - pip install -r requirements-dev.txt
   - pip install -e .
+  - pip install "dask[distributed]" --upgrade
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ipcluster start -n 2 --daemonize ; fi

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Changelog
 =========
 
+- Fix small issues in ABC-SMC which did not work in 1-dimensional problems or with output names
 - Update README.md
 
 0.7.7 (2020-10-12)

--- a/elfi/methods/parameter_inference.py
+++ b/elfi/methods/parameter_inference.py
@@ -631,6 +631,7 @@ class SMC(Sampler):
 
         """
         model, discrepancy_name = self._resolve_model(model, discrepancy_name)
+        output_names = [discrepancy_name] + model.parameter_names + (output_names or [])
 
         super(SMC, self).__init__(model, output_names, **kwargs)
 

--- a/elfi/methods/utils.py
+++ b/elfi/methods/utils.py
@@ -249,7 +249,7 @@ class GMDistribution:
 
     @staticmethod
     def _normalize_params(means, weights):
-        means = np.atleast_1d(means)
+        means = np.atleast_1d(np.squeeze(means))
         if means.ndim > 2:
             raise ValueError('means.ndim = {} but must be at most 2.'.format(means.ndim))
 


### PR DESCRIPTION
* fix output names

SMC did not work with additional output names. this was because additional output names were interpreted as the full output names list and essential variables were not recorded.

* fix mismatched dimension

previous version resulted in mismatch between dimensions when mean vectors are 1-dimensional. this was due to an extra dimension which is now removed in parameter normalisation.

* update changelog

* Upgrade dask explicitly for travis

Co-authored-by: hpesonen <henri.e.pesonen@gmail.com>

#### Summary:
Please provide a short summary here

#### Please make sure

- [ ] You have updated the CHANGELOG.rst
- [ ] You have provided a short summary of your changes (see previous section)
- [ ] You have listed the copyright holder for the work you are submitting (see next section)

If your contribution adds, removes or somehow changes the functional behavior of the package, please check that

- [ ] You have included or updated all the relevant documentation
- [ ] The proposed changes pass all unit tests (check step 6 of CONTRIBUTING.rst for details)
- [ ] You have added appropriate unit tests to ensure the new features behave as expected

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting (this will be you or your assignee, such as a university or company):

By submitting this pull request, the copyright holder is agreeing to license the submitted work under the following licenses:
- Code: BSD3 (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
